### PR TITLE
fix: platformCommit を boolean から string に修正

### DIFF
--- a/default.json
+++ b/default.json
@@ -20,7 +20,7 @@
   "rebaseWhen": "conflicted",
   "labels": ["dependencies"],
   "rangeStrategy": "bump",
-  "platformCommit": true,
+  "platformCommit": "enabled",
   "platformAutomerge": true,
   "major": {
     "automerge": false,


### PR DESCRIPTION
## 概要
Renovate 共通設定 `default.json` の `platformCommit` が boolean (`true`) になっており、最新スキーマ（`"auto" | "disabled" | "enabled"`）と不一致だったため修正しました。

## 変更内容
- `default.json`
  - `"platformCommit": true` -> `"platformCommit": "enabled"`

## 期待される効果
- `extends: ["github>thundermiracle/.github"]` を利用するリポジトリで、Renovate の設定検証エラー（Fix Renovate Configuration）を回避
- Renovate PR 作成の再開