### PR TITLE
ci: add scheduled Renovate config validation run

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -5,6 +5,10 @@ on:
     branches:
       - main
   pull_request:
+  schedule:
+    # Every Monday at 01:00 JST (Sunday 16:00 UTC)
+    - cron: "0 16 * * 0"
+  workflow_dispatch:
 
 env:
   LOG_LEVEL: debug


### PR DESCRIPTION
## 概要
Renovate 設定検証を定期実行できるように、既存 workflow のトリガーを拡張しました。

## 変更内容
- `/Users/fengliu/Code/.github/.github/workflows/test.yml`
  - `schedule` を追加（毎週月曜 01:00 JST / 日曜 16:00 UTC）
  - `workflow_dispatch` を追加（手動実行用）

## 目的
- push/PR がなくても Renovate スキーマ変更や設定互換性の崩れを早期検知するため